### PR TITLE
Fix misspelled package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A simple utility that lists out all registered routes in your express applicatio
 
 const express = require("express");
 
-const routeList = require("express-route-catelogue");
+const routeList = require("express-routes-catalogue");
 const app = express();
 
 app.get("/", (req, res) => {
@@ -48,7 +48,7 @@ if (process.env.NODE_ENV === "development") {
 ``` js
 
 const express = require("express");
-const routeList = require("express-route-catelogue");
+const routeList = require("express-routes-catalogue");
 const app = express();
 
 app.get("/", (req, res) => {
@@ -65,7 +65,7 @@ if (process.env.NODE_ENV === "development") {
 
 ...
 ```
-Now navigation to your-application/route-list, you can see full routes list.
+Now Navigate to your-application/route-list, you can see full routes list.
 
 
 ## Contribution


### PR DESCRIPTION
Does not resolve (mistyped package name)
- `const routeList = require("express-route-catelogue");`,
Corrected
- `const routeList = require("express-routes-catalogue");`

Additionally fixes grammer on L68.